### PR TITLE
fix: add PIXABAY_API_KEY env var to Claude PR comment workflow

### DIFF
--- a/.github/workflows/claude-pr-comment.yml
+++ b/.github/workflows/claude-pr-comment.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          PIXABAY_API_KEY: ${{ secrets.PIXABAY_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebFetch"


### PR DESCRIPTION
The add-recipe workflow already had the Pixabay API key, but the
PR comment workflow was missing it, preventing Claude from
downloading recipe images when triggered via PR comments.

https://claude.ai/code/session_01Tdgi4bnoDg8GQdm7ps2MK7