### PR TITLE
Fix search input focus zoom on mobile in homepage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -128,7 +128,7 @@ export function HomePage() {
               placeholder={t("home.searchPlaceholder")}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="bg-transparent border-none shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 w-full text-sm font-body placeholder:text-outline p-0 h-auto"
+              className="bg-transparent border-none shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 w-full text-base md:text-sm font-body placeholder:text-outline p-0 h-auto"
             />
             <Link
               to="/recipes?openFilters=1"


### PR DESCRIPTION
Use text-base (16px) on mobile for the homepage search input to prevent
iOS Safari from auto-zooming on focus, matching the fix already applied
in the SearchBar component used on the recipes page.

https://claude.ai/code/session_01EFZiEKoCkSwRehC7kiupWT