### PR TITLE
fix: update tests to match current UI text and layout

### DIFF
--- a/src/test/HomePage.test.tsx
+++ b/src/test/HomePage.test.tsx
@@ -52,8 +52,8 @@ describe("HomePage", () => {
   it("renders category cards after loading", async () => {
     renderHomePage()
     await waitFor(() => {
-      expect(screen.getByText(/01 — Antipasti/)).toBeInTheDocument()
-      expect(screen.getByText(/02 — Dolci/)).toBeInTheDocument()
+      expect(screen.getByText(/1 — Antipasti/)).toBeInTheDocument()
+      expect(screen.getByText(/1 — Dolci/)).toBeInTheDocument()
     })
   })
 
@@ -70,7 +70,7 @@ describe("HomePage", () => {
   it("links category cards to filtered recipes page", async () => {
     renderHomePage()
     await waitFor(() => {
-      const antipastiLink = screen.getByText(/01 — Antipasti/).closest("a")
+      const antipastiLink = screen.getByText(/1 — Antipasti/).closest("a")
       expect(antipastiLink).toHaveAttribute("href", "/recipes?category=Antipasti")
     })
   })
@@ -79,7 +79,7 @@ describe("HomePage", () => {
     const user = userEvent.setup()
     renderHomePage()
     await waitFor(() => {
-      expect(screen.getByText(/01 — Antipasti/)).toBeInTheDocument()
+      expect(screen.getByText(/1 — Antipasti/)).toBeInTheDocument()
     })
 
     const input = screen.getByPlaceholderText("Search a recipe...")
@@ -87,7 +87,7 @@ describe("HomePage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Pasta alla Carbonara")).toBeInTheDocument()
-      expect(screen.queryByText(/01 — Antipasti/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/1 — Antipasti/)).not.toBeInTheDocument()
     })
   })
 
@@ -95,18 +95,18 @@ describe("HomePage", () => {
     const user = userEvent.setup()
     renderHomePage()
     await waitFor(() => {
-      expect(screen.getByText(/01 — Antipasti/)).toBeInTheDocument()
+      expect(screen.getByText(/1 — Antipasti/)).toBeInTheDocument()
     })
 
     const input = screen.getByPlaceholderText("Search a recipe...")
     await user.type(input, "carbonara")
     await waitFor(() => {
-      expect(screen.queryByText(/01 — Antipasti/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/1 — Antipasti/)).not.toBeInTheDocument()
     })
 
     await user.clear(input)
     await waitFor(() => {
-      expect(screen.getByText(/01 — Antipasti/)).toBeInTheDocument()
+      expect(screen.getByText(/1 — Antipasti/)).toBeInTheDocument()
     })
   })
 
@@ -114,15 +114,15 @@ describe("HomePage", () => {
     const user = userEvent.setup()
     renderHomePage()
     await waitFor(() => {
-      expect(screen.getByText(/01 — Antipasti/)).toBeInTheDocument()
+      expect(screen.getByText(/1 — Antipasti/)).toBeInTheDocument()
     })
 
     const input = screen.getByPlaceholderText("Search a recipe...")
     await user.type(input, "xyznotarecipe")
 
     await waitFor(() => {
-      expect(screen.getByText("No recipe found")).toBeInTheDocument()
-      expect(screen.queryByText(/01 — Antipasti/)).not.toBeInTheDocument()
+      expect(screen.getByText("Mamma mia, the pot is empty!")).toBeInTheDocument()
+      expect(screen.queryByText(/1 — Antipasti/)).not.toBeInTheDocument()
     })
   })
 })

--- a/src/test/RecipeGrid.test.tsx
+++ b/src/test/RecipeGrid.test.tsx
@@ -49,7 +49,7 @@ describe("RecipeGrid", () => {
 
   it("shows empty state when no recipes", () => {
     renderGrid({ recipes: [] })
-    expect(screen.getByText("No recipe found")).toBeInTheDocument()
+    expect(screen.getByText("Mamma mia, the pot is empty!")).toBeInTheDocument()
   })
 
   it("renders a card per recipe", () => {

--- a/src/test/RecipePage.test.tsx
+++ b/src/test/RecipePage.test.tsx
@@ -63,35 +63,35 @@ describe("RecipePage", () => {
     const user = userEvent.setup()
     renderRecipePage("pasta-carbonara")
     await waitFor(() => {
-      expect(screen.getByText("400g spaghetti")).toBeInTheDocument()
-      expect(screen.getByText("200g guanciale")).toBeInTheDocument()
+      expect(screen.getAllByText("400g spaghetti").length).toBeGreaterThan(0)
+      expect(screen.getAllByText("200g guanciale").length).toBeGreaterThan(0)
     })
 
-    // Click label to check an ingredient
-    const label = screen.getByText("400g spaghetti").closest("label")!
+    // Click label to check an ingredient (use first match — mobile tab view)
+    const label = screen.getAllByText("400g spaghetti")[0].closest("label")!
     await user.click(label)
-    expect(screen.getByText("400g spaghetti")).toHaveClass("line-through")
+    expect(screen.getAllByText("400g spaghetti")[0]).toHaveClass("line-through")
   })
 
   it("switches to instructions tab", async () => {
     const user = userEvent.setup()
     renderRecipePage("pasta-carbonara")
     await waitFor(() => {
-      expect(screen.getByText("400g spaghetti")).toBeInTheDocument()
+      expect(screen.getAllByText("400g spaghetti").length).toBeGreaterThan(0)
     })
 
-    await user.click(screen.getByText("Instructions"))
-    expect(screen.getByText("Portare a ebollizione l'acqua.")).toBeInTheDocument()
-    expect(screen.getByText("Rosolare il guanciale.")).toBeInTheDocument()
+    await user.click(screen.getAllByText("Instructions")[0])
+    expect(screen.getAllByText("Portare a ebollizione l'acqua.").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Rosolare il guanciale.").length).toBeGreaterThan(0)
   })
 
-  it("shows not found for missing recipe", async () => {
+  it("shows error state for missing recipe", async () => {
     globalThis.fetch = async () =>
       ({ ok: false } as Response)
 
     renderRecipePage("nonexistent")
     await waitFor(() => {
-      expect(screen.getByText("Recipe not found")).toBeInTheDocument()
+      expect(screen.getByText("Failed to load. Please try again.")).toBeInTheDocument()
     })
   })
 

--- a/src/test/RecipesPage.test.tsx
+++ b/src/test/RecipesPage.test.tsx
@@ -182,7 +182,7 @@ describe("RecipesPage", () => {
     await user.type(input, "xyznotarecipe")
 
     await waitFor(() => {
-      expect(screen.getByText("No recipe found")).toBeInTheDocument()
+      expect(screen.getByText("Mamma mia, the pot is empty!")).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Tests were broken by prior UI changes:
- Category cards now show recipe count instead of index number
- Empty state text changed to "Mamma mia, the pot is empty!"
- Recipe not found now shows error state with retry button
- Ingredients/instructions render in both mobile and desktop layouts

https://claude.ai/code/session_01MstktgYFqge5BBgqQb4hG6