### PR TITLE
Make the origin label on a recipe page a link

### DIFF
--- a/src/pages/RecipePage.tsx
+++ b/src/pages/RecipePage.tsx
@@ -408,9 +408,12 @@ export function RecipePage() {
           {t(`categories.${recipe.category}`, recipe.category)}
         </span>
         {recipe.origin && recipe.origin !== "none" && (
-          <span className="block text-[10px] uppercase tracking-[0.15em] text-muted-foreground mt-1">
+          <Link
+            to={`/recipes?origin=${encodeURIComponent(recipe.origin)}`}
+            className="block text-[10px] uppercase tracking-[0.15em] text-muted-foreground mt-1 hover:text-primary transition-colors"
+          >
             {t(`origins.${recipe.origin}`, recipe.origin)}
-          </span>
+          </Link>
         )}
 
         {/* Title */}

--- a/src/test/RecipePage.test.tsx
+++ b/src/test/RecipePage.test.tsx
@@ -140,4 +140,23 @@ describe("RecipePage", () => {
       expect(screen.getByTestId("recipes-page")).toBeInTheDocument()
     })
   })
+
+  it("renders the origin label as a link to the recipes page filtered by that origin", async () => {
+    globalThis.fetch = async () =>
+      ({ ok: true, json: async () => ({ ...mockRecipe, origin: "amelie" }) }) as Response
+    renderRecipePage("pasta-carbonara")
+    await waitFor(() => {
+      expect(screen.getByText("Amélie's recipe")).toBeInTheDocument()
+    })
+    const originLink = screen.getByText("Amélie's recipe").closest("a")!
+    expect(originLink).toHaveAttribute("href", "/recipes?origin=amelie")
+  })
+
+  it("renders no origin label when the recipe has no origin", async () => {
+    renderRecipePage("pasta-carbonara")
+    await waitFor(() => {
+      expect(screen.getByText("Pasta alla Carbonara")).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/'s recipe/)).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Sur la fiche d'une recette, le label d'origine (« RECETTE D'AMÉLIE », « RECETTE DE PIERRICK »…) était un simple `<span>`, donc non cliquable. Il pointe maintenant vers la liste filtrée sur cette origine.

## Changement

`src/pages/RecipePage.tsx` : le `<span>` devient un `<Link to={/recipes?origin=...}>`, avec un `hover:text-primary` pour l'affordance.

C'est exactement la convention déjà en place pour les tags de la même fiche, qui pointent vers `/recipes?tag=...`, et pour les catégories de la home, qui pointent vers `/recipes?category=...`. `RecipesPage` lit déjà le paramètre `origin` de l'URL (`src/pages/RecipesPage.tsx:85`), il n'y avait donc rien à ajouter côté destination.

## Tests

Deux tests ajoutés à `src/test/RecipePage.test.tsx`, écrits avant l'implémentation :

- le label d'origine est un lien vers `/recipes?origin=amelie`
- aucun label d'origine n'est rendu quand la recette n'en a pas

Le premier échouait bien avant le changement (`closest("a")` renvoyait `null`).

## Vérification en conditions réelles

Testé dans le navigateur sur `#/recipe/galette-banane` : le clic sur « AMÉLIE'S RECIPE » mène à `#/recipes?origin=amelie`, la puce de filtre « Amélie's recipe » est active, le compteur de filtres affiche 1 et la recette correspondante s'affiche.

## Une limite connue, inchangée

`RecipesPage` ne remet à zéro les filtres sauvegardés que si un paramètre `category` est présent dans l'URL (`src/pages/RecipesPage.tsx:65`). Arriver via `?origin=` conserve donc les filtres précédemment enregistrés, qui se croisent avec l'origine.

Les liens `?tag=` existants ont déjà exactement ce comportement, donc ce n'est pas une régression introduite ici et je n'ai pas touché à cette logique partagée. À traiter séparément si ça pose problème à l'usage.

## Vérifications

- `npm run lint` : aucun problème
- `npm run test` : 148 passés, les 4 échecs restants sont les evals préexistants, identiques sur `main`
- `npm run build` : OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)