### PR TITLE
Set the crêpes cook time to a realistic 30 minutes

### DIFF
--- a/public/data/recipes/crepes-chandeleur.json
+++ b/public/data/recipes/crepes-chandeleur.json
@@ -11,7 +11,7 @@
     "url": "https://pixabay.com/users/ritae-19628/"
   },
   "prepTime": 5,
-  "cookTime": 10,
+  "cookTime": 30,
   "servings": 4,
   "difficulty": "Facile",
   "category": "Dolci",

--- a/public/data/recipes/index.json
+++ b/public/data/recipes/index.json
@@ -5966,7 +5966,7 @@
       "url": "https://pixabay.com/users/ritae-19628/"
     },
     "prepTime": 5,
-    "cookTime": 10,
+    "cookTime": 30,
     "servings": 4,
     "difficulty": "Facile",
     "category": "Dolci",


### PR DESCRIPTION
Passe le `cookTime` de `crepes-chandeleur` de 10 à 30 minutes, dans la recette et dans l'index.

La valeur de 10 minutes venait de la page d'Hervé Cuisine, mais elle ne tient pas face aux 15 à 20 crêpes que la même page annonce. C'est un écart assumé avec la source, au profit d'une durée utilisable.

Ce changement avait été poussé sur la branche de la PR #77 quelques secondes après son merge, il n'y a donc jamais atterri. Cette PR le réapplique proprement sur main.

## Vérifications

- `npm run validate:recipes` : 95 tests passent
- `npm run build` : OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)